### PR TITLE
fix: fixed tag name for anck:0.5.0-beta.18

### DIFF
--- a/manifests/anck/kustomization.yaml
+++ b/manifests/anck/kustomization.yaml
@@ -7,7 +7,7 @@ namespace: anck
 images:
   - name: ci4rail/anck:latest
     newName: ghcr.io/edgefarm/anck
-    newTag: v0.5.0-beta.18
+    newTag: 0.5.0-beta.18
 
 resources:
   - https://github.com/edgefarm/anck/config/default/?ref=v0.5.0-beta.18


### PR DESCRIPTION
`anck` cannot be pulled. The tag of the anck image does not contain `v`.

```Events:
  Type    Reason   Age                     From     Message
  ----    ------   ----                    ----     -------
  Normal  BackOff  3m49s (x2669 over 10h)  kubelet  Back-off pulling image "ghcr.io/edgefarm/anck:v0.5.0-beta.18"
```
